### PR TITLE
unique file path filter for js sources

### DIFF
--- a/bundles/resource/src/main/java/de/matrixweb/smaller/resource/SourceMerger.java
+++ b/bundles/resource/src/main/java/de/matrixweb/smaller/resource/SourceMerger.java
@@ -14,17 +14,20 @@ import org.codehaus.jackson.map.ObjectMapper;
  */
 public class SourceMerger {
 
-  private final Boolean uniqueFiles;
+  private final boolean uniqueFiles;
 
+  /**
+   * all source files are merged regardless of multiple occurrences
+   */
   public SourceMerger() {
-    this.uniqueFiles = Boolean.FALSE;
+    this.uniqueFiles = false;
   }
 
   /**
    * @param uniqueFiles
    *          flag to resolve a json source files just once
    */
-  public SourceMerger(final Boolean uniqueFiles) {
+  public SourceMerger(final boolean uniqueFiles) {
     this.uniqueFiles = uniqueFiles;
   }
 
@@ -102,14 +105,15 @@ public class SourceMerger {
   }
 
   /**
-   * Examines a source file if it is already resolved when it should be unique.
+   * Examines a source file whether it is already resolved when it should be
+   * unique.
    * 
    * @param alreadyHandled
    *          all source files already resolved
    * @param s
    *          source file to resolve
-   * @return
-   *        true if source files should be unique and the source file was not resolved yet
+   * @return true if source files should be unique and the source file already
+   *         resolved
    */
   private boolean isUniqueFileResolved(final Set<String> alreadyHandled,
       final String s) {

--- a/bundles/resource/src/test/java/de/matrixweb/smaller/resource/SourceMergerTest.java
+++ b/bundles/resource/src/test/java/de/matrixweb/smaller/resource/SourceMergerTest.java
@@ -3,10 +3,12 @@ package de.matrixweb.smaller.resource;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -14,26 +16,46 @@ import org.junit.Test;
  */
 public class SourceMergerTest {
 
+  private static String absoluteResourcesPath;
+
+  /**
+   * @throws IOException
+   */
+  @BeforeClass
+  public static void setupTestClass() throws IOException {
+    final String currentPath = new File(".").getCanonicalPath();
+    absoluteResourcesPath = currentPath + "/src/test/resources";
+  }
+
+  /**
+   * @throws IOException
+   */
   @Test
   public void testUniqueFileResolving() throws IOException {
-    final String tempFolder = "/tmp";
-    final ResourceResolver resolver = new FileResourceResolver(tempFolder);
-    final SourceMerger merger = new SourceMerger(Boolean.TRUE);
+    final ResourceResolver resolver = new FileResourceResolver(
+        SourceMergerTest.absoluteResourcesPath);
+    final SourceMerger merger = new SourceMerger(true);
     final List<String> resourcesFiles = new ArrayList<String>();
     resourcesFiles.add("basic.json");
     final List<Resource> resources = merger.getResources(resolver,
         resourcesFiles);
     assertThat(resources.size(), is(2));
-    assertThat(resources.get(0).getURL().getPath(), is(tempFolder
-        + "/extensions/js/ext/json2.js"));
-    assertThat(resources.get(1).getURL().getPath(), is(tempFolder
-        + "/extensions/js/ext/modernizr.custom.js"));
+    assertThat(resources.get(0).getURL().getPath(),
+        is(SourceMergerTest.absoluteResourcesPath
+            + "/extensions/js/ext/json2.js"));
+    assertThat(resources.get(1).getURL().getPath(),
+        is(SourceMergerTest.absoluteResourcesPath
+            + "/extensions/js/ext/modernizr.custom.js"));
   }
 
+  /**
+   * @throws IOException
+   */
   @Test
   public void testMutlipleFileResolving() throws IOException {
-    final String tempFolder = "/tmp";
-    final ResourceResolver resolver = new FileResourceResolver(tempFolder);
+
+    final ResourceResolver resolver = new FileResourceResolver(
+        SourceMergerTest.absoluteResourcesPath);
     final SourceMerger merger = new SourceMerger();
     final List<String> resourcesFiles = new ArrayList<String>();
     resourcesFiles.add("basic.json");
@@ -42,23 +64,32 @@ public class SourceMergerTest {
 
     assertThat(resources.size(), is(9));
 
-    assertThat(resources.get(0).getURL().getPath(), is(tempFolder
-        + "/extensions/js/ext/json2.js"));
-    assertThat(resources.get(1).getURL().getPath(), is(tempFolder
-        + "/extensions/js/ext/modernizr.custom.js"));
-    assertThat(resources.get(2).getURL().getPath(), is(tempFolder
-        + "/extensions/js/ext/modernizr.custom.js"));
-    assertThat(resources.get(3).getURL().getPath(), is(tempFolder
-        + "/extensions/js/ext/json2.js"));
-    assertThat(resources.get(4).getURL().getPath(), is(tempFolder
-        + "/extensions/js/ext/modernizr.custom.js"));
-    assertThat(resources.get(5).getURL().getPath(), is(tempFolder
-        + "/extensions/js/ext/json2.js"));
-    assertThat(resources.get(6).getURL().getPath(), is(tempFolder
-        + "/extensions/js/ext/json2.js"));
-    assertThat(resources.get(7).getURL().getPath(), is(tempFolder
-        + "/extensions/js/ext/modernizr.custom.js"));
-    assertThat(resources.get(8).getURL().getPath(), is(tempFolder
-        + "/extensions/js/ext/json2.js"));
+    assertThat(resources.get(0).getURL().getPath(),
+        is(SourceMergerTest.absoluteResourcesPath
+            + "/extensions/js/ext/json2.js"));
+    assertThat(resources.get(1).getURL().getPath(),
+        is(SourceMergerTest.absoluteResourcesPath
+            + "/extensions/js/ext/modernizr.custom.js"));
+    assertThat(resources.get(2).getURL().getPath(),
+        is(SourceMergerTest.absoluteResourcesPath
+            + "/extensions/js/ext/modernizr.custom.js"));
+    assertThat(resources.get(3).getURL().getPath(),
+        is(SourceMergerTest.absoluteResourcesPath
+            + "/extensions/js/ext/json2.js"));
+    assertThat(resources.get(4).getURL().getPath(),
+        is(SourceMergerTest.absoluteResourcesPath
+            + "/extensions/js/ext/modernizr.custom.js"));
+    assertThat(resources.get(5).getURL().getPath(),
+        is(SourceMergerTest.absoluteResourcesPath
+            + "/extensions/js/ext/json2.js"));
+    assertThat(resources.get(6).getURL().getPath(),
+        is(SourceMergerTest.absoluteResourcesPath
+            + "/extensions/js/ext/json2.js"));
+    assertThat(resources.get(7).getURL().getPath(),
+        is(SourceMergerTest.absoluteResourcesPath
+            + "/extensions/js/ext/modernizr.custom.js"));
+    assertThat(resources.get(8).getURL().getPath(),
+        is(SourceMergerTest.absoluteResourcesPath
+            + "/extensions/js/ext/json2.js"));
   }
 }

--- a/bundles/resource/src/test/resources/basic.json
+++ b/bundles/resource/src/test/resources/basic.json
@@ -1,0 +1,11 @@
+[
+  "extensions/js/ext/json2.js",
+  "extensions/js/ext/modernizr.custom.js",
+  "extensions/js/ext/modernizr.custom.js",
+  "extensions/js/ext/json2.js",
+  "extensions/js/ext/modernizr.custom.js",
+  "extensions/js/ext/json2.js",
+  "extensions/js/ext/json2.js",
+  "extensions/js/ext/modernizr.custom.js",
+  "extensions/js/ext/json2.js"
+]


### PR DESCRIPTION
Hej Markus,

this is a simple version to filter js sources by path if  a unique flag is set.
There should be no influence on the existing behaviour.  To ensure this, two plain tests are included.

I didn't commit the test resources as it did not seem to be appropriate and am not happy about the method name for documenting the filtering which finally led to the name 'isUniqueFileResolved'. 

Anyway, I'm considering to examine the content to really exclude duplicates.

Cheers
ronny
